### PR TITLE
Open GitHub link in new tab

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -23,7 +23,11 @@ export async function Header() {
             size="sm"
             className="hidden md:flex"
           >
-            <Link href="https://github.com/lucas-ht/42calculator">
+            <Link
+              href="https://github.com/lucas-ht/42calculator"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <GitHub className="mr-2 size-6" />
               Star on GitHub
             </Link>


### PR DESCRIPTION
# Description

When click on start on GitHub button, it loads Github's site in same tab. 
Change behavior to open in a new tab.

## Evidences

> Old behavior

https://github.com/user-attachments/assets/f6e4eeba-70c1-4680-9c19-43a92b2020f1

> new behavior

https://github.com/user-attachments/assets/c3cc3512-0651-47ec-a1b8-c62d8e02585d

